### PR TITLE
feat: added simple api health check endpoint(GET /health)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -180,7 +180,6 @@
       "integrity": "sha512-/NbVmcGTP+lj5oa4yiYxxeBjRivKQ5Ns1eSZeB99ExsEQ6rX5XYU1Zy/gGxY/ilqtD4Etx9mKyrPxZRetiahhA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.14.0"
       }
@@ -1742,7 +1741,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -6,11 +6,13 @@ import healthRoutes from './routes/healthRoutes';
 
 const app: Application = express();
 
+
 // Middleware setup
 app.use(cors());
 app.use(morgan('dev'));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
+
 
 // API Routes
 app.use('/api/health', healthRoutes);

--- a/backend/src/controllers/healthController.ts
+++ b/backend/src/controllers/healthController.ts
@@ -1,9 +1,8 @@
 import { Request, Response, NextFunction } from 'express';
- //Responds with { status: "ok" } if server is running
+
 export const healthCheck = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    // will Simulate async if needed for check DB connection)
-    return res.status(200).json({ status: 'ok' });
+    return res.status(200).json({ status: 'ok' });// Responds with { status: "ok" } if server is running
   } catch (error) {
     next(error);
   }

--- a/backend/src/routes/healthRoutes.ts
+++ b/backend/src/routes/healthRoutes.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { healthCheck } from '../controllers/healthController';
 
+
 const router = Router();
 router.get('/', healthCheck);
 


### PR DESCRIPTION
## Description

Added a /health endpoint to the backend:

- Created `healthController` to handle the route logic.
- Created `healthRoutes` to define the route.
- Imported `healthRoutes` into `app.ts` under `/api/health`.

This endpoint responds with `{ status: "ok" }` to confirm the API is running.

## Semver Changes

- [ ] Patch (bug fix, no new features)
- [x] Minor (new features, no breaking changes)
- [ ] Major (breaking changes)

## Issues

- closes #7 

## Checklist

- [x] I have read the [Contributing Guidelines](../Contributor_Guide/Contruting.md).

